### PR TITLE
Fix scoring bugs

### DIFF
--- a/xfl/src/symbolnlp.py
+++ b/xfl/src/symbolnlp.py
@@ -1039,7 +1039,7 @@ class SmithWaterman:
         """
             Calculates similarity matrix for 2 sequences 
         """
-        H = np.zeros((len(a)+1, len(b)+1), np.int)
+        H = np.zeros((len(a)+1, len(b)+1), int)
 
         for i, j in itertools.product(range(1, H.shape[0]), range(1, H.shape[1])):
             match   = H[i-1, j-1] + self.match_score if a[i-1] == b[j-1] else - self.match_score

--- a/xfl/src/symbolnlp.py
+++ b/xfl/src/symbolnlp.py
@@ -853,17 +853,21 @@ class SymbolNLP:
         ac  = self.canonical_set(a)
         bc  = self.canonical_set(b)
         outer_scores = []
-        for aw, bw in itertools.product(ac, bc):
-            inner_scores = []
-            synset_aw   = wn.synsets(aw)
-            synset_bw   = wn.synsets(bw)
-            for a_ss, b_ss in itertools.product(synset_aw, synset_bw):
-                d = wn.wup_similarity(a_ss, b_ss)
-                word_sims.add(d)
-                inner_scores.append(d)
-            if len(inner_scores) > 0:
-                outer_scores.append(max(inner_scores))
-
+        for aw in ac:
+            word_scores = []
+            for bw in bc:
+                inner_scores = []
+                synset_aw   = wn.synsets(aw)
+                synset_bw   = wn.synsets(bw)
+                for a_ss, b_ss in itertools.product(synset_aw, synset_bw):
+                    d = wn.wup_similarity(a_ss, b_ss)
+                    word_sims.add(d)
+                    inner_scores.append(d)
+                if len(inner_scores) > 0:
+                    word_scores.append(max(inner_scores))
+            # print(f"word: {aw}, scores: {word_scores}")
+            if len(word_scores) > 0:
+                outer_scores.append(max(word_scores))
         return np.mean(outer_scores) if len(outer_scores) > 0 else 0.0
 
 

--- a/xfl/src/symbolnlp.py
+++ b/xfl/src/symbolnlp.py
@@ -516,7 +516,7 @@ class SymbolNLP:
         """
         #perms = itertools.permutations(abbrs)
         #perms = itertools.combinations(abbrs)
-        combs = self._combinations_with_condition(list(abbrs), len(name))
+        combs = self._combinations_with_condition(sorted(abbrs), len(name))
         bscore = -1
         bset = set([])
         for comb in combs:
@@ -563,7 +563,7 @@ class SymbolNLP:
         return set(words)
 
 
-    def find_subabbreviations(self, alpha_chars):
+    def find_subabbreviations(self, alpha_chars) -> set[str]:
         """
             convert strcmp -> [string, compare]
             getlanguagespecificdata -> [get, language, specific, data]


### PR DESCRIPTION
The current set similarity scoring has two bugs which I'm sharing fixes for here:
* Scores deteriorate the longer the sets are. Two equal sets of size 2 get a better score than two equal sets of size 4. To fix this, don't average the scores for the cross product of the sets, but take the best match for each word.
* Best-cut-of-the-rod is not deterministic. Depending on the iteration order of a hash set, the similarity scores can fluctuate. Sort the sets to get an (arbitrary) fixed iteration order for reproducible scores.